### PR TITLE
update helm_release.yaml

### DIFF
--- a/infra/apiserver/helm_release.yaml
+++ b/infra/apiserver/helm_release.yaml
@@ -14,4 +14,4 @@ spec:
   interval: "1m"
   values:
     image:
-      tag: "da66ff32538dd5d06944e57cc0be0beccb319a6e"
+      tag: "a863618710b24a5c6b1480897f4b0b99d3d4839e"


### PR DESCRIPTION
Update to https://github.com/venturemark/apiserver/pull/62. @marcusellison note that you do not have to deploy `apiserver` manually anymore. Upon `kia create knd` the `apiserver` is being deployed automatically. 